### PR TITLE
Remove duplicate compress input

### DIFF
--- a/WDL/v2.5_MongoSwirl_Single/AlignAndCallR1_v2_5_Single.wdl
+++ b/WDL/v2.5_MongoSwirl_Single/AlignAndCallR1_v2_5_Single.wdl
@@ -86,7 +86,6 @@ workflow AlignAndCallR1 {
         suffix = '.nuc',
         mt_interval_list = nuc_interval_list,
 
-        compress = compress_output_vcf,
         m2_extra_args = select_first([m2_extra_args, ""]),
 
         max_alt_allele_count = 4,


### PR DESCRIPTION
Fixes the following error detected by miniWDL:

```wdl
(WDL/v2.5_MongoSwirl_Single/fullMitoPipeline_v2_5_Single.wdl Ln 3 Col 1) Failed to import https://raw.githubusercontent.com/rahulg603/mtSwirl/master/WDL/v2.5_MongoSwirl_Single/AlignAndCallR1_v2_5_Single.wdl
(https://raw.githubusercontent.com/rahulg603/mtSwirl/master/WDL/v2.5_MongoSwirl_Single/AlignAndCallR1_v2_5_Single.wdl Ln 78 Col 7) duplicate call input 'compress'
          input:
          ^^^^^^
```